### PR TITLE
Fix compatibility with Normal Ancient Teleports plugin

### DIFF
--- a/src/main/java/net/antipixel/nexus/NexusMapPlugin.java
+++ b/src/main/java/net/antipixel/nexus/NexusMapPlugin.java
@@ -263,9 +263,13 @@ public class NexusMapPlugin extends Plugin
 
 				// But also index it by its alias. This is for compatibility with plugins
 				// that change the vanilla name to the alias in the Nexus menu
-				if (teleportDef.hasAlias())
+				if (teleportDef.hasAliases())
 				{
-					this.teleportDefinitions.put(teleportDef.getAlias(), teleportDef);
+					for (String alias : teleportDef.getAliases())
+					{
+						this.teleportDefinitions.put(alias, teleportDef);
+					}
+					// TODO: Only sets the first alias (Specifically for Better Teleport)
 					this.teleportDefinitions.put(getParenthesisedName(teleportDef), teleportDef);
 				}
 			}
@@ -809,7 +813,8 @@ public class NexusMapPlugin extends Plugin
 	 */
 	private String getParenthesisedName(TeleportDefinition teleportDef)
 	{
-		return String.format(PARENTHESISED_ALIAS_FORMAT, teleportDef.getAlias(), teleportDef.getName());
+		// TODO: Always use first alias for now
+		return String.format(PARENTHESISED_ALIAS_FORMAT, teleportDef.hasAliases() ? teleportDef.getAliases()[0] : null, teleportDef.getName());
 	}
 
 	/**
@@ -819,7 +824,8 @@ public class NexusMapPlugin extends Plugin
 	 */
 	private String getParenthesisedAlias(TeleportDefinition teleportDef)
 	{
-		return String.format(PARENTHESISED_ALIAS_FORMAT, teleportDef.getName(), teleportDef.getAlias());
+		// TODO: Always use first alias for now
+		return String.format(PARENTHESISED_ALIAS_FORMAT, teleportDef.getName(), teleportDef.hasAliases() ? teleportDef.getAliases()[0] : null);
 	}
 
 	/**
@@ -1040,11 +1046,18 @@ public class NexusMapPlugin extends Plugin
 	{
 		// First check the teleport isn't using an alias. This can occur if the user
 		// has another plugin installed that is altering the name of the teleport.
-		if (this.availableTeleports.containsKey(teleportDefinition.getAlias()))
+		if (teleportDefinition.hasAliases())
 		{
-			return this.availableTeleports.get(teleportDefinition.getAlias());
+			for (String alias : teleportDefinition.getAliases())
+			{
+				if (this.availableTeleports.containsKey(alias))
+				{
+					return this.availableTeleports.get(alias);
+				}
+			}
 		}
 
+		// TODO: Only using first alias (Specifically for Better Teleport)
 		if (this.availableTeleports.containsKey(this.getParenthesisedName(teleportDefinition)))
 		{
 			return this.availableTeleports.get(this.getParenthesisedName(teleportDefinition));

--- a/src/main/java/net/antipixel/nexus/Teleport.java
+++ b/src/main/java/net/antipixel/nexus/Teleport.java
@@ -47,7 +47,8 @@ public class Teleport
 	 */
 	public String getAlias()
 	{
-		return this.definition.getAlias();
+		// TODO: Using first alias only for now
+		return this.definition.hasAliases() ? this.definition.getAliases()[0] : null;
 	}
 
 	/**
@@ -56,7 +57,7 @@ public class Teleport
 	 */
 	public boolean hasAlias()
 	{
-		return this.definition.getAlias() != null;
+		return this.definition.hasAliases();
 	}
 
 	/**

--- a/src/main/java/net/antipixel/nexus/definition/TeleportDefinition.java
+++ b/src/main/java/net/antipixel/nexus/definition/TeleportDefinition.java
@@ -12,7 +12,7 @@ public class TeleportDefinition
 {
 	private int structID;
 	private String name;
-	private String alias;
+	private String[] aliases;
 	public int spriteX;
 	public int spriteY;
 	private int enabledSprite;
@@ -22,8 +22,8 @@ public class TeleportDefinition
 	 * Checks if this teleport has an alias defined
 	 * @return true if the teleport has an alias, otherwise false
 	 */
-	public boolean hasAlias()
+	public boolean hasAliases()
 	{
-		return this.alias != null;
+		return this.aliases != null && this.aliases.length > 0;
 	}
 }

--- a/src/main/resources/net/antipixel/nexus/definition/RegionDef.json
+++ b/src/main/resources/net/antipixel/nexus/definition/RegionDef.json
@@ -14,7 +14,7 @@
       {
         "structID":459,
         "name":"Senntisten",
-        "alias":"Digsite",
+        "aliases":["Digsite", "Exam Centre"],
         "spriteX":281,
         "spriteY":165,
         "enabledSprite":342,
@@ -161,7 +161,7 @@
       {
         "structID": 461,
         "name":"Kharyrll",
-        "alias":"Canifis",
+        "aliases":["Canifis"],
         "spriteX":99,
         "spriteY":110,
         "enabledSprite":343,
@@ -192,7 +192,7 @@
       {
         "structID": 466,
         "name":"Annakarl",
-        "alias":"Demonic Ruins",
+        "aliases":["Demonic Ruins"],
         "spriteX":297,
         "spriteY":85,
         "enabledSprite":347,
@@ -201,7 +201,7 @@
       {
         "structID": 469,
         "name":"Ghorrock",
-        "alias":"Frozen Waste Plateau",
+        "aliases":["Frozen Waste Plateau", "Frozen Waste"],
         "spriteX":143,
         "spriteY":89,
         "enabledSprite":348,
@@ -210,7 +210,7 @@
       {
         "structID": 470,
         "name":"Carrallanger",
-        "alias":"Graveyard of Shadows",
+        "aliases":["Graveyard of Shadows"],
         "spriteX":241,
         "spriteY":197,
         "enabledSprite":346,
@@ -273,7 +273,7 @@
       {
         "structID": 460,
         "name":"Marim",
-        "alias":"Ape Atoll",
+        "aliases":["Ape Atoll"],
         "spriteX":431,
         "spriteY":231,
         "enabledSprite":357,


### PR DESCRIPTION
A bit of a cludge to support extra aliases from Normal Ancient Teleports plugin.

For now, assumes the first alias is the one to be used for the whole Better Teleports plugin thing, and this breaks if both plugins are running at once, although if someone is doing that, what are they doing?

Like, bro...
![image](https://github.com/user-attachments/assets/c0e2096e-c034-44db-bb71-6acd0ffd604b)

Anyways...

Fixes #21.