### PR TITLE
Fix compatibility issues by checking Sprites instead of Teleport Names

### DIFF
--- a/src/main/java/net/antipixel/nexus/IntegerBooleanPair.java
+++ b/src/main/java/net/antipixel/nexus/IntegerBooleanPair.java
@@ -1,0 +1,14 @@
+package net.antipixel.nexus;
+
+import lombok.Value;
+
+/**
+ * Integer/Boolean value pair
+ * @author Cyborger1
+ */
+@Value
+public class IntegerBooleanPair
+{
+	int integerValue;
+	boolean booleanValue;
+}

--- a/src/main/java/net/antipixel/nexus/NexusMapPlugin.java
+++ b/src/main/java/net/antipixel/nexus/NexusMapPlugin.java
@@ -108,7 +108,7 @@ public class NexusMapPlugin extends Plugin
 	private static final String DEF_FILE_REGIONS = "RegionDef.json";
 	private static final String DEF_FILE_SPRITES = "SpriteDef.json";
 
-	private static final String TELE_NAME_PATTERN = "<col=ffffff>(.+)</col> :  (.+)";
+	private static final String TELE_NAME_PATTERN = "<col=ffffff>(.+)</col> : +(.+)";
 	private static final String PARENTHESISED_ALIAS_FORMAT = "%s (%s)";
 	private static final String SHORTCUT_COLOUR_TAG = "<col=ffffff>";
 	private static final String PLUGIN_NAME_BTM = "Better Teleport Menu";
@@ -517,7 +517,6 @@ public class NexusMapPlugin extends Plugin
 			Widget sprite = sprites[i];
 
 			String shortcutKey;
-			String teleportName;
 
 			// For teleports with a shortcut defined, the teleport widget text will
 			// contain the shortcut key sandwiched between colour tags. If these tags
@@ -535,13 +534,11 @@ public class NexusMapPlugin extends Plugin
 
 				// Extract the pertinent information
 				shortcutKey = matcher.group(1);
-				teleportName = matcher.group(2);
 			}
 			else
 			{
 				// No shortcut key defined
 				shortcutKey = null;
-				teleportName = label.getText();
 			}
 
 			IntegerBooleanPair key = new IntegerBooleanPair(sprite.getSpriteId(), alt);

--- a/src/main/java/net/antipixel/nexus/NexusMapPlugin.java
+++ b/src/main/java/net/antipixel/nexus/NexusMapPlugin.java
@@ -494,10 +494,6 @@ public class NexusMapPlugin extends Plugin
 			return teleports;
 		}
 
-		// Compile the pattern that will match the teleport label
-		// and place the hotkey and teleport name into groups
-		Pattern pattern = Pattern.compile(TELE_NAME_PATTERN);
-
 		// Grab the children of the widget, each of which have a text
 		// attribute containing the teleport location name and key shortcut
 		Widget[] labels = labelsWidget.getDynamicChildren();
@@ -510,6 +506,10 @@ public class NexusMapPlugin extends Plugin
 		{
 			return teleports;
 		}
+
+		// Compile the pattern that will match the teleport label
+		// and place the hotkey and teleport name into groups
+		Pattern pattern = Pattern.compile(TELE_NAME_PATTERN);
 
 		for (int i = 0; i < labels.length; i++)
 		{

--- a/src/main/java/net/antipixel/nexus/NexusMapPlugin.java
+++ b/src/main/java/net/antipixel/nexus/NexusMapPlugin.java
@@ -139,9 +139,9 @@ public class NexusMapPlugin extends Plugin
 
 	private RegionDefinition[] regionDefinitions;
 	private SpriteDefinition[] spriteDefinitions;
+
 	private Map<IntegerBooleanPair, TeleportDefinition> teleportDefinitions;
 	private Map<IntegerBooleanPair, Teleport> availableTeleports;
-
 	private Map<IntegerBooleanPair, UIButton> activeTeleportButtons;
 
 	private boolean mapEnabled;

--- a/src/main/java/net/antipixel/nexus/NexusMapPlugin.java
+++ b/src/main/java/net/antipixel/nexus/NexusMapPlugin.java
@@ -68,7 +68,9 @@ public class NexusMapPlugin extends Plugin
 	private static final int ID_TELEPORT_LIST = 0x11000B;
 	private static final int ID_LOC_LABELS_PRIMARY = 0x11000C;
 	private static final int ID_SCROLLBAR = 0x11000E;
+	private static final int ID_SPRITES_PRIMARY = 0x11000F;
 	private static final int ID_LOC_LABELS_ALTERNATE = 0x110010;
+	private static final int ID_SPRITES_ALTERNATE = 0x110012;
 
 	/* Widget dimensions and positions */
 	private static final int TELE_ICON_SIZE = 24;
@@ -137,14 +139,14 @@ public class NexusMapPlugin extends Plugin
 
 	private RegionDefinition[] regionDefinitions;
 	private SpriteDefinition[] spriteDefinitions;
-	private Map<String, TeleportDefinition> teleportDefinitions;
+	private Map<IntegerBooleanPair, TeleportDefinition> teleportDefinitions;
+	private Map<IntegerBooleanPair, Teleport> availableTeleports;
+
+	private Map<IntegerBooleanPair, UIButton> activeTeleportButtons;
 
 	private boolean mapEnabled;
 	private boolean switchingModes;
 	private String teleportAction;
-
-	private Map<String, Teleport> availableTeleports;
-	private Map<String, UIButton> activeTeleportButtons;
 
 	/* Widgets */
 	private List<Integer> hiddenWidgetIDs;
@@ -258,16 +260,7 @@ public class NexusMapPlugin extends Plugin
 		{
 			for (TeleportDefinition teleportDef : regionDef.getTeleportDefinitions())
 			{
-				// Place the teleport definition in the lookup table indexed by its name
-				this.teleportDefinitions.put(teleportDef.getName(), teleportDef);
-
-				// But also index it by its alias. This is for compatibility with plugins
-				// that change the vanilla name to the alias in the Nexus menu
-				if (teleportDef.hasAlias())
-				{
-					this.teleportDefinitions.put(teleportDef.getAlias(), teleportDef);
-					this.teleportDefinitions.put(getParenthesisedName(teleportDef), teleportDef);
-				}
+				this.teleportDefinitions.put(teleportDef.getKey(), teleportDef);
 			}
 		}
 	}
@@ -415,13 +408,13 @@ public class NexusMapPlugin extends Plugin
 		this.buildAvailableTeleportList();
 
 		// Update only the active teleports
-		for (String teleportName : this.activeTeleportButtons.keySet())
+		for (Map.Entry<IntegerBooleanPair, UIButton> entry : this.activeTeleportButtons.entrySet())
 		{
-			// Grab the active teleport using its name
-			UIButton teleportButton = this.activeTeleportButtons.get(teleportName);
+			// Grab the active teleport
+			UIButton teleportButton = entry.getValue();
 
 			// Update the widget name
-			TeleportDefinition teleportDef = this.teleportDefinitions.get(teleportName);
+			TeleportDefinition teleportDef = this.teleportDefinitions.get(entry.getKey());
 			Teleport teleport = this.getAvailableTeleport(teleportDef);
 			teleportButton.setName(this.generateTeleportName(teleport));
 		}
@@ -434,19 +427,10 @@ public class NexusMapPlugin extends Plugin
 	{
 		this.availableTeleports = new HashMap<>();
 
-		// Compile the pattern that will match the teleport label
-		// and place the hotkey and teleport name into groups
-		Pattern labelPattern = Pattern.compile(TELE_NAME_PATTERN);
-
-		// Get the parent widgets containing the label list, for both
-		// the primary type teleports and alternate type
-		Widget primaryParent = this.client.getWidget(ID_LOC_LABELS_PRIMARY);
-		Widget alternateParent = this.client.getWidget(ID_LOC_LABELS_ALTERNATE);
-
 		// Fetch all teleports for both the primary and alternate teleport widgets,
 		// appending the results of both to the available teleports maps
-		this.availableTeleports.putAll(this.getTeleportsFromLabelWidget(primaryParent, false, labelPattern));
-		this.availableTeleports.putAll(this.getTeleportsFromLabelWidget(alternateParent, true, labelPattern));
+		this.availableTeleports.putAll(this.getTeleportsFromWidgets(false));
+		this.availableTeleports.putAll(this.getTeleportsFromWidgets(true));
 	}
 
 	/**
@@ -492,32 +476,56 @@ public class NexusMapPlugin extends Plugin
 	 * Extracts information from a nexus portals teleport list and returns the information as a Teleport list,
 	 * containing the name, index, shortcut key and type of teleport (either primary or alternate)
 	 *
-	 * @param labelParent the widget containing a teleport list
-	 * @param alt         true if this widget contains alternate teleports, false if primary
-	 * @param pattern     a compiled pattern for matching the text contained in the list item widgets
-	 * @return a list containing all available teleports for the provided widget
+	 * @param alt         true if grabbing alternate teleports, false if primary
+	 * @return a list containing all available teleports
 	 */
-	private Map<String, Teleport> getTeleportsFromLabelWidget(Widget labelParent, boolean alt, Pattern pattern)
+	private Map<IntegerBooleanPair, Teleport> getTeleportsFromWidgets(boolean alt)
 	{
-		// Grab the children of the widget, each of which have a text
-		// attribute containing the teleport location name and key shortcut
-		Widget[] labelWidgets = labelParent.getDynamicChildren();
+		// Get the parent widgets containing the sprite/labels list
+		Widget labelsWidget = this.client.getWidget(alt ? ID_LOC_LABELS_ALTERNATE : ID_LOC_LABELS_PRIMARY);
+		Widget spritesWidget = this.client.getWidget(alt ? ID_SPRITES_ALTERNATE : ID_SPRITES_PRIMARY);
 
 		// Create a map in which to place the available teleport options
-		Map<String, Teleport> teleports = new HashMap<>();
+		Map<IntegerBooleanPair, Teleport> teleports = new HashMap<>();
 
-		for (Widget child : labelWidgets)
+		// Early return
+		if (labelsWidget == null || spritesWidget == null)
 		{
+			return teleports;
+		}
+
+		// Compile the pattern that will match the teleport label
+		// and place the hotkey and teleport name into groups
+		Pattern pattern = Pattern.compile(TELE_NAME_PATTERN);
+
+		// Grab the children of the widget, each of which have a text
+		// attribute containing the teleport location name and key shortcut
+		Widget[] labels = labelsWidget.getDynamicChildren();
+
+		// Grab the children of the widget, each of which have a sprite
+		Widget[] sprites = spritesWidget.getDynamicChildren();
+
+		// Sanity check
+		if (labels.length == 0 || labels.length != sprites.length)
+		{
+			return teleports;
+		}
+
+		for (int i = 0; i < labels.length; i++)
+		{
+			Widget label = labels[i];
+			Widget sprite = sprites[i];
+
 			String shortcutKey;
 			String teleportName;
 
 			// For teleports with a shortcut defined, the teleport widget text will
 			// contain the shortcut key sandwiched between colour tags. If these tags
 			// are present, the shortcut key and teleport name will need to be extracted.
-			if (child.getText().contains(SHORTCUT_COLOUR_TAG))
+			if (label.getText().contains(SHORTCUT_COLOUR_TAG))
 			{
 				// Create a pattern matcher with the widgets text content
-				Matcher matcher = pattern.matcher(child.getText());
+				Matcher matcher = pattern.matcher(label.getText());
 
 				// If the text doesn't match the pattern, skip onto the next
 				if (!matcher.matches())
@@ -533,20 +541,22 @@ public class NexusMapPlugin extends Plugin
 			{
 				// No shortcut key defined
 				shortcutKey = null;
-				teleportName = child.getText();
+				teleportName = label.getText();
 			}
 
-			// If a teleport by this name cannot be found in the teleport definitions,
+			IntegerBooleanPair key = new IntegerBooleanPair(sprite.getSpriteId(), alt);
+
+			// If a teleport by this spriteID cannot be found in the teleport definitions,
 			// skip. This likely means a new teleport has been added to the Nexus that
 			// hasn't been updated into the definitions yet
-			if (!this.teleportDefinitions.containsKey(teleportName))
+			if (!this.teleportDefinitions.containsKey(key))
 			{
 				continue;
 			}
 
 			// Get the teleport definition from the lookup table
-			TeleportDefinition teleportDef = this.teleportDefinitions.get(teleportName);
-			teleports.put(teleportName, new Teleport(teleportDef, child, shortcutKey, alt));
+			TeleportDefinition teleportDef = this.teleportDefinitions.get(key);
+			teleports.put(key, new Teleport(teleportDef, label, shortcutKey));
 		}
 
 		return teleports;
@@ -757,8 +767,7 @@ public class NexusMapPlugin extends Plugin
 						teleportButton.addAction(ACTION_TEXT_HOTKEY, () -> triggerRebindDialog(teleport));
 					}
 
-					// Add to the list of active teleport buttons
-					this.activeTeleportButtons.put(teleportDef.getName(), teleportButton);
+					this.activeTeleportButtons.put(teleportDef.getKey(), teleportButton);
 				}
 				else
 				{
@@ -1038,19 +1047,7 @@ public class NexusMapPlugin extends Plugin
 	 */
 	private Teleport getAvailableTeleport(TeleportDefinition teleportDefinition)
 	{
-		// First check the teleport isn't using an alias. This can occur if the user
-		// has another plugin installed that is altering the name of the teleport.
-		if (this.availableTeleports.containsKey(teleportDefinition.getAlias()))
-		{
-			return this.availableTeleports.get(teleportDefinition.getAlias());
-		}
-
-		if (this.availableTeleports.containsKey(this.getParenthesisedName(teleportDefinition)))
-		{
-			return this.availableTeleports.get(this.getParenthesisedName(teleportDefinition));
-		}
-
-		return this.availableTeleports.get(teleportDefinition.getName());
+		return this.availableTeleports.get(teleportDefinition.getKey());
 	}
 
 	/**

--- a/src/main/java/net/antipixel/nexus/Teleport.java
+++ b/src/main/java/net/antipixel/nexus/Teleport.java
@@ -11,25 +11,21 @@ import net.runelite.api.widgets.Widget;
 @Getter
 public class Teleport
 {
-	private TeleportDefinition definition;
-	private Widget widget;
-	private String keyShortcut;
-	private boolean alt;
+	private final TeleportDefinition definition;
+	private final Widget widget;
+	private final String keyShortcut;
 
 	/**
 	 * Creates a new teleport instance
 	 * @param definition the teleport definition
 	 * @param widget the widget for this teleport option
 	 * @param key the keyboard shortcut
-	 * @param alt true if this teleport is an alternate type,
-	 *            for example the Grand Exchange is an alternate of Varrock
 	 */
-	public Teleport(TeleportDefinition definition, Widget widget, String key, boolean alt)
+	public Teleport(TeleportDefinition definition, Widget widget, String key)
 	{
 		this.definition = definition;
 		this.widget = widget;
 		this.keyShortcut = key;
-		this.alt = alt;
 	}
 
 	/**
@@ -39,6 +35,11 @@ public class Teleport
 	public String getName()
 	{
 		return this.definition.getName();
+	}
+
+	public boolean isAlt()
+	{
+		return this.definition.isAlt();
 	}
 
 	/**

--- a/src/main/java/net/antipixel/nexus/Teleport.java
+++ b/src/main/java/net/antipixel/nexus/Teleport.java
@@ -57,7 +57,7 @@ public class Teleport
 	 */
 	public boolean hasAlias()
 	{
-		return this.definition.getAlias() != null;
+		return this.definition.hasAlias();
 	}
 
 	/**

--- a/src/main/java/net/antipixel/nexus/definition/TeleportDefinition.java
+++ b/src/main/java/net/antipixel/nexus/definition/TeleportDefinition.java
@@ -31,7 +31,7 @@ public class TeleportDefinition
 
 	/**
 	 * Gets the key to be used to identify this TeleportDefinition
-	 * @return The IntergerBooleanPair key
+	 * @return The IntegerBooleanPair key
 	 */
 	public IntegerBooleanPair getKey()
 	{

--- a/src/main/java/net/antipixel/nexus/definition/TeleportDefinition.java
+++ b/src/main/java/net/antipixel/nexus/definition/TeleportDefinition.java
@@ -30,7 +30,9 @@ public class TeleportDefinition
 	}
 
 	/**
-	 * Gets the key to be used to identify this TeleportDefinition
+	 * Gets the key to be used to identify this TeleportDefinition, based on enabledSprite and isAlt.
+	 * Alternate teleports share the same sprite ID as their primary counterpart,
+	 * but are stored under a separate widget in-game, allowing us to identify them this way.
 	 * @return The IntegerBooleanPair key
 	 */
 	public IntegerBooleanPair getKey()

--- a/src/main/java/net/antipixel/nexus/definition/TeleportDefinition.java
+++ b/src/main/java/net/antipixel/nexus/definition/TeleportDefinition.java
@@ -1,6 +1,7 @@
 package net.antipixel.nexus.definition;
 
 import lombok.Getter;
+import net.antipixel.nexus.IntegerBooleanPair;
 
 /**
  * Contains data that defines a teleport destination.
@@ -12,6 +13,7 @@ public class TeleportDefinition
 {
 	private int structID;
 	private String name;
+	private boolean isAlt;
 	private String alias;
 	public int spriteX;
 	public int spriteY;
@@ -25,5 +27,14 @@ public class TeleportDefinition
 	public boolean hasAlias()
 	{
 		return this.alias != null;
+	}
+
+	/**
+	 * Gets the key to be used to identify this TeleportDefinition
+	 * @return The IntergerBooleanPair key
+	 */
+	public IntegerBooleanPair getKey()
+	{
+		return new IntegerBooleanPair(this.enabledSprite, this.isAlt);
 	}
 }

--- a/src/main/resources/net/antipixel/nexus/definition/RegionDef.json
+++ b/src/main/resources/net/antipixel/nexus/definition/RegionDef.json
@@ -39,6 +39,7 @@
       {
         "structID":451,
         "name":"Grand Exchange",
+        "isAlt":true,
         "spriteX":200,
         "spriteY":107,
         "enabledSprite":27,
@@ -147,8 +148,8 @@
         "name":"Salve Graveyard",
         "spriteX":79,
         "spriteY":119,
-        "enabledSprite":1254,
-        "disabledSprite":1279
+        "enabledSprite":1258,
+        "disabledSprite":1283
       },
       {
         "structID": 1252,
@@ -282,6 +283,7 @@
       {
         "structID": 458,
         "name":"Yanille",
+        "isAlt":true,
         "spriteX":188,
         "spriteY":267,
         "enabledSprite":55,
@@ -314,6 +316,7 @@
       {
         "structID": 455,
         "name":"Seers\u0027 Village",
+        "isAlt":true,
         "spriteX":256,
         "spriteY":67,
         "enabledSprite":37,


### PR DESCRIPTION
Checking if the `enabledSprite` is in the teleports list to indentify available teleports lets us avoid looking at names, which may have been changed. Just hoping there isn't a plugin that changes sprites in the future though...

The main idea is to store the teleports in the hashmaps using a combination of their SpriteID and if they're an alt teleport (alt teleports use the same SpriteID as their primary counterpart).

We do still need to hit the label widgets to grab the shortcut, as Better Teleport hijacks the keyEvent widgets. It may be possible to do a hybrid approach where we check both, but for now I'd rather avoid that.